### PR TITLE
Fixed db.batch(), improved tests, added readme note on db.batch() chained, updated to level / fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ behave deterministically - `level-update` does a get, and then combines the
 current value with the new value. It is essetial that the value has not 
 changed in between the get and the put!
 
+## NOTE
+
+`level-update` doesn't support the [chained interface](https://github.com/rvagg/node-levelup#dbbatch-chained-form) for db.batch(), but only the [array interface](https://github.com/rvagg/node-levelup#dbbatcharray-options-callback-array-form).
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -17,12 +17,12 @@ module.exports = function (db, opts) {
 
   var merge = opts.merge
 
-  var put = db.put, del = db.del
+  var put = db.put, del = db.del, batch = db.batch
 
   function op (key, value, cb) {
     var ks = key.toString()
     if(ks < opts.start || opts.end < ks)
-      return put.call(db, key, value, options, cb) 
+      return put.call(db, key, value, options, cb)
 
     db.get(key, function (err, _value) {
       if(err && err.name != 'NotFoundError') return cb(err)
@@ -82,10 +82,10 @@ module.exports = function (db, opts) {
 
           item.value = value
 
-          if(done --> 0) return //not the last thing yet..
+          if(--done) return //not the last thing yet..
 
           //if this was the last operation...
-          batch.call(ops, options, _cb)
+          batch.call(db, ops, options, _cb)
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "tape": "~0.2.2",
     "rimraf": "~2.1.2",
-    "levelup": "~0.5.3"
+    "level": "0.17.x"
   },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"

--- a/test/batch.js
+++ b/test/batch.js
@@ -1,5 +1,5 @@
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 

--- a/test/del.js
+++ b/test/del.js
@@ -1,5 +1,5 @@
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 

--- a/test/lock.js
+++ b/test/lock.js
@@ -22,7 +22,7 @@ I don't actually care which one wins, as long as only one wins.
 */
 
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 

--- a/test/put.js
+++ b/test/put.js
@@ -1,5 +1,5 @@
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 

--- a/test/read-your-writes.js
+++ b/test/read-your-writes.js
@@ -1,5 +1,5 @@
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 
@@ -20,24 +20,50 @@ rimraf(path, function () {
 
   tape('test', function (t) {
 
-    var r = 'VALUE' + Math.random(), r2 = 'value2' + Math.random()
-
     levelup(path, function (err, db) {
       var called = 0
-      var k = 'key_' + Math.random()
-      var v = 'val_' + Math.random()
-      var n = 1000, r = 1000
+      var n = 1000, r = 1000, r2 = 1000
+      var counter = 2, ops = []
 
-      while(n--) {
+      function tryToEnd() {
+        if (!--counter)
+          t.end()
+      }
 
-        db.put(k, v, function () {
-          db.get(k, function (err, val) {
-            t.equal(val, v)
+      function putAndGet(key, value) {
+        db.put(key, value, function () {
+          db.get(key, function (err, val) {
+            t.equal(val, val)
             if(!--r)
-              t.end()
+              tryToEnd()
           })
         })
       }
+
+      while(n--) {
+        putAndGet('key_' + Date.now(), 'val_' + Date.now())
+
+        ops.push({
+          type  : 'put',
+          key   : ('batch_key_' + n),
+          value : ('batch_val_' + n)
+        })
+      }
+
+      db.batch(ops, function(err) {
+        t.ok(err == null)
+
+        db.createKeyStream({
+          start   : 'batch_key_\xff',
+          end     : 'batch_key_\x00',
+          reverse : true
+        }).on('data', function(item) {
+          --r2
+        }).on('end', function(){
+          t.equal(r2, 0)
+          tryToEnd()
+        });
+      })
     })
   })
 })

--- a/test/version.js
+++ b/test/version.js
@@ -1,5 +1,5 @@
 
-var levelup = require('levelup')
+var levelup = require('level')
 var tape    = require('tape')
 var rimraf  = require('rimraf')
 
@@ -48,7 +48,7 @@ rimraf(path, function () {
 
       db.put('key', JSON.stringify(r), function (err, _r) {
         console.log('1')
-        t.equal(err, null)
+        t.ok(err == null)
         db.put('key', JSON.stringify(r_wrong), function (err) {
         console.log(2)
           t.notEqual(err, null)


### PR DESCRIPTION
- `db.batch()` had multiple bugs and was totally non-functional, so I've fixed that and improved the tests to make sure it does work (it inserts the records into the db for ex).
- I've added a README note that we don't support the chained interface for `db.batch()`, but only the array one (I guess at the time you wrote this lib there was only the array interface). We can support this later if we want to though.
- I've updated to `level` last version instead of a really old `levelup` version (dev deps, package.json)

I've added some comments to the code.
